### PR TITLE
Survey 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## DOCKER
+docker/**

--- a/survey-api/src/main/java/org/kong/survey/controller/SurveyController.java
+++ b/survey-api/src/main/java/org/kong/survey/controller/SurveyController.java
@@ -19,9 +19,11 @@ public class SurveyController {
     private final SurveyFacade surveyFacade;
 
     @GetMapping("")
-    public ResponseEntity<ResponseCommon<Object>> getSurveyList(@RequestParam(value = "page") int page, @RequestParam(value = "size") int size) {
-        PageDto surveyFindAll = surveyFacade.findAllSurvey(page, size);
-
+    public ResponseEntity<ResponseCommon<Object>> getSurveyList(@RequestParam(value = "page") int page,
+                                                                @RequestParam(value = "size") int size,
+                                                                @RequestParam(value = "search") String search){
+        PageDto surveyFindAll = surveyFacade.findAllSurvey(page, size, search);
+        
         ResponseCommon<Object> response = ResponseCommon
                 .builder()
                 .code(1)

--- a/survey-api/src/main/java/org/kong/survey/dto/Question.java
+++ b/survey-api/src/main/java/org/kong/survey/dto/Question.java
@@ -22,6 +22,7 @@ public class Question {
         private QuestionType questionType;
         private String question;
         private int order;
+        private boolean isRequired;
         List<SurveyAnswer.Request> answers;
     }
 

--- a/survey-api/src/main/java/org/kong/survey/facade/SurveyFacade.java
+++ b/survey-api/src/main/java/org/kong/survey/facade/SurveyFacade.java
@@ -25,8 +25,13 @@ public class SurveyFacade {
     private final SurveyMapper surveyMapper;
     private final QuestionMapper questionMapper;
 
-    public PageDto findAllSurvey(int page, int size) {
-        Page<SurveyEntity> surveyList = surveyService.findAll(page, size);
+    public PageDto findAllSurvey(int page, int size, String search) {
+        Page<SurveyEntity> surveyList;
+        if (search != null && !search.trim().isEmpty()) {
+            surveyList = surveyService.findBySurveyTitle(page, size, search);
+        } else {
+            surveyList = surveyService.findAll(page, size);
+        }
         PageDto surveyFindAll = surveyMapper.toSurveyFindAll(surveyList);
 
         return surveyFindAll;
@@ -42,8 +47,10 @@ public class SurveyFacade {
     }
 
     public Survey.Response add(Survey.Request request) {
+        // 설문지 추가
         SurveyEntity survey = surveyService.add(request);
 
+        // 질문지 추가
         List<QuestionEntity> questionEntities = questionMapper.toQuestionEntityList(survey, request.getQuestions());
         questionService.addAll(questionEntities);
 

--- a/survey-api/src/main/java/org/kong/survey/service/SurveyService.java
+++ b/survey-api/src/main/java/org/kong/survey/service/SurveyService.java
@@ -29,6 +29,13 @@ public class SurveyService {
         return surveyList;
     }
 
+    public Page<SurveyEntity> findBySurveyTitle(int page, int size, String surveyTitle) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<SurveyEntity> surveyList = surveyRepository.findBySurveyTitle(pageRequest, surveyTitle);
+
+        return surveyList;
+    }
+
     public SurveyEntity findBySurveyId(Integer surveyId) {
         SurveyEntity survey = surveyRepository.findBySurveyId(surveyId).orElseThrow(() -> new CustomException(ErrorCode.SERVICE_NOT_FOUND));
 

--- a/survey-api/src/test/java/question/QuestionServiceTest.java
+++ b/survey-api/src/test/java/question/QuestionServiceTest.java
@@ -43,8 +43,8 @@ public class QuestionServiceTest {
         QuestionType questionType2 = QuestionType.SUB;
 
         List<QuestionEntity> mockitoQuestions = List.of(
-                new QuestionEntity(questionId1, question1, questionType1,1, SurveyEntity.builder().surveyId(surveyId).build()),
-                new QuestionEntity(questionId2, question2, questionType2,2, SurveyEntity.builder().surveyId(surveyId).build())
+                new QuestionEntity(questionId1, question1, questionType1, 1, true, SurveyEntity.builder().surveyId(surveyId).build()),
+                new QuestionEntity(questionId2, question2, questionType2, 2, false, SurveyEntity.builder().surveyId(surveyId).build())
         );
 
         when(questionRepository.findBySurvey_surveyId(surveyId)).thenReturn(mockitoQuestions);
@@ -75,10 +75,9 @@ public class QuestionServiceTest {
         QuestionType questionType2 = QuestionType.SUB;
 
         List<QuestionEntity> questionEntities = List.of(
-                new QuestionEntity(questionId1, question1, questionType1,1, SurveyEntity.builder().surveyId(surveyId).build()),
-                new QuestionEntity(questionId2, question2, questionType2,2, SurveyEntity.builder().surveyId(surveyId).build())
+                new QuestionEntity(questionId1, question1, questionType1, 1, true, SurveyEntity.builder().surveyId(surveyId).build()),
+                new QuestionEntity(questionId2, question2, questionType2, 2, false, SurveyEntity.builder().surveyId(surveyId).build())
         );
-
 
         // when
         questionService.addAll(questionEntities);
@@ -115,13 +114,13 @@ public class QuestionServiceTest {
         QuestionType questionType2 = QuestionType.SUB;
 
         List<QuestionEntity> savedQuestions = List.of(
-                new QuestionEntity(questionId1, question1, questionType1,1, SurveyEntity.builder().surveyId(surveyId).build()),
-                new QuestionEntity(questionId2, question2, questionType2,2, SurveyEntity.builder().surveyId(surveyId).build())
+                new QuestionEntity(questionId1, question1, questionType1, 1, true, SurveyEntity.builder().surveyId(surveyId).build()),
+                new QuestionEntity(questionId2, question2, questionType2, 2, false, SurveyEntity.builder().surveyId(surveyId).build())
         );
 
         List<QuestionEntity> changeQuestions = List.of(
-                new QuestionEntity(questionId1, question1, questionType1,1, SurveyEntity.builder().surveyId(surveyId).build()),
-                new QuestionEntity(questionId2, question2, questionType2,2, SurveyEntity.builder().surveyId(surveyId).build())
+                new QuestionEntity(questionId1, question1, questionType1, 1, true, SurveyEntity.builder().surveyId(surveyId).build()),
+                new QuestionEntity(questionId2, question2, questionType2, 2, false, SurveyEntity.builder().surveyId(surveyId).build())
         );
 
         when(questionRepository.saveAll(savedQuestions)).thenReturn(changeQuestions);
@@ -132,7 +131,6 @@ public class QuestionServiceTest {
         // then
         assertEquals(changeQuestions, result);
         verify(questionRepository, times(1)).saveAll(savedQuestions);
-
     }
 
     @Test
@@ -149,8 +147,8 @@ public class QuestionServiceTest {
         QuestionType questionType2 = QuestionType.SUB;
 
         List<QuestionEntity> mockitoQuestions = List.of(
-                new QuestionEntity(questionId1, question1, questionType1,1, SurveyEntity.builder().surveyId(surveyId).build()),
-                new QuestionEntity(questionId2, question2, questionType2,2, SurveyEntity.builder().surveyId(surveyId).build())
+                new QuestionEntity(questionId1, question1, questionType1, 1, true, SurveyEntity.builder().surveyId(surveyId).build()),
+                new QuestionEntity(questionId2, question2, questionType2, 2, false, SurveyEntity.builder().surveyId(surveyId).build())
         );
 
         when(questionRepository.findBySurvey_surveyId(surveyId)).thenReturn(mockitoQuestions);

--- a/survey-api/src/test/java/survey/SurveyFacadeTest.java
+++ b/survey-api/src/test/java/survey/SurveyFacadeTest.java
@@ -54,7 +54,8 @@ class SurveyFacadeTest {
         when(surveyMapper.toSurveyFindAll(mockPage)).thenReturn(pageDto);
 
         // when
-        PageDto result = surveyFacade.findAllSurvey(page, size);
+        String search = "title";
+        PageDto result = surveyFacade.findAllSurvey(page, size, search);
 
         // then
         assertThat(pageDto).isEqualTo(result);

--- a/survey-api/src/test/java/userAnswer/UserAnswerServiceTest.java
+++ b/survey-api/src/test/java/userAnswer/UserAnswerServiceTest.java
@@ -52,9 +52,9 @@ public class UserAnswerServiceTest {
         String userAnswer2 = "168";
 
         UserEntity userEntity = new UserEntity("테스트", "테스트", "USER");
-        QuestionEntity questionEntity1 = new QuestionEntity(questionId1, question1, questionType1, 1,
+        QuestionEntity questionEntity1 = new QuestionEntity(questionId1, question1, questionType1, 1, true,
                 SurveyEntity.builder().surveyId(surveyId).build());
-        QuestionEntity questionEntity2 = new QuestionEntity(questionId2, question2, questionType2, 2,
+        QuestionEntity questionEntity2 = new QuestionEntity(questionId2, question2, questionType2, 2, false,
                 SurveyEntity.builder().surveyId(surveyId).build());
         List<QuestionEntity> questionEntityList = List.of(questionEntity1, questionEntity2);
 
@@ -93,9 +93,9 @@ public class UserAnswerServiceTest {
         LocalDateTime now = LocalDateTime.now();
 
         UserEntity userEntity = new UserEntity("테스트", "테스트", "USER");
-        QuestionEntity questionEntity1 = new QuestionEntity(questionId1, question1, questionType1, 1,
+        QuestionEntity questionEntity1 = new QuestionEntity(questionId1, question1, questionType1, 1, true,
                 SurveyEntity.builder().surveyId(surveyId).build());
-        QuestionEntity questionEntity2 = new QuestionEntity(questionId2, question2, questionType2, 2,
+        QuestionEntity questionEntity2 = new QuestionEntity(questionId2, question2, questionType2, 2, false,
                 SurveyEntity.builder().surveyId(surveyId).build());
 
         List<UserAnswerEntity> userAnswerEntities = List.of(

--- a/survey-common/src/main/java/org/kong/exception/ErrorCode.java
+++ b/survey-common/src/main/java/org/kong/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.OK, "U001", 101, "사용자를 찾을 수 없습니다."),
-    SERVICE_NOT_FOUND(HttpStatus.OK, "S001", 101, "설문지를 찾을 수 없습니다.");
+    SERVICE_NOT_FOUND(HttpStatus.OK, "S001", 101, "설문지를 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND(HttpStatus.OK, "Q001", 101, "질문지를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String error;

--- a/survey-domain/src/main/java/org/kong/survey/entity/QuestionEntity.java
+++ b/survey-domain/src/main/java/org/kong/survey/entity/QuestionEntity.java
@@ -24,17 +24,21 @@ public class QuestionEntity {
     @Column
     private int questionOrder;
 
+    @Column
+    private boolean isRequired;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "survey_id")
     private SurveyEntity survey;
 
     @Builder
     public QuestionEntity(Integer questionId, String question, QuestionType questionType, int questionOrder,
-            SurveyEntity survey) {
+            boolean isRequired, SurveyEntity survey) {
         this.questionId = questionId;
         this.question = question;
         this.questionType = questionType;
         this.questionOrder = questionOrder;
+        this.isRequired = isRequired;
         this.survey = survey;
     }
 }

--- a/survey-domain/src/main/java/org/kong/survey/repository/QuestionRepository.java
+++ b/survey-domain/src/main/java/org/kong/survey/repository/QuestionRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<QuestionEntity, Long> {
 
     List<QuestionEntity> findBySurvey_surveyId(Integer surveyId);
+    
+    Optional<QuestionEntity> findByQuestionId(Integer questionId);
 }

--- a/survey-domain/src/main/java/org/kong/survey/repository/SurveyRepository.java
+++ b/survey-domain/src/main/java/org/kong/survey/repository/SurveyRepository.java
@@ -21,6 +21,8 @@ public interface SurveyRepository extends JpaRepository<SurveyEntity, Long> {
 
     Page<SurveyEntity> findAll(Pageable pageable);
 
+    Page<SurveyEntity> findBySurveyTitle(Pageable pageable, String surveyTitle);
+
     Optional<SurveyEntity> findBySurveyId(Integer surveyId);
 
     SurveyEntity save(SurveyEntity survey);


### PR DESCRIPTION
## 📌 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대해 간단히 설명해주세요. -->
- 설문지 제목으로 검색 기능 추가
- 질문 필수 답변 여부 기능 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 명시해주세요. 예: Closes #123 -->
f6830d852fb1f8eca8835d42c1139b2e3719f4b8: 설문지 제목 검색
478b31e6f82cef17f0c7ca664cb3b5396695d47e: 질문 필수 답변 여부

## 🛠️ 변경 사항
<!-- 주요 변경 사항을 요약해주세요. 예: 새로운 컴포넌트 추가, 기존 로직 수정 등 -->
설문지 제목 검색
- Survey 변경: SurveyController, SurveyEntity, SurveyFacade
- Question 변경: Question.Request, UserSurveyFacade

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 새로운 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 업데이트했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.

## ❓ 생각해야 할 포인트
- JWT 토큰을 사용해서 개발하면 csrf.disable() 하는 게 맞는 건지? 
-> 보안은 하면 할 수록 좋다 / 인터넷에서 오는 정보를 믿지 말아라
- JWT 단점인 쿠키, 세션보다 길이가 길어 네트워크 부하 증가, 탈취 시 강제로 만료 하기 어려움
-> 둘 다 인증하는 토큰이라서 중복되어 사용하지 않는 게 이득? / 둘 다 토큰 검증하니까 더 안전?
-> JWT라고 안전하지 않다. 
- 모듈: 모듈화 함으로 다른 프로젝트에 필요한 코드를 재사용 
  - 모듈로 인해 독립적인 서비스 분리를 하면, 비용 상승 -> 분리하지 않으면 안되겠다는 순간까지 미루는 것이 좋다
  - 어떤 구조가 더욱 적합한지 프로젝트가 진화함에 따라 **구조가 달라질 수 있다.**
- 분리 기준
```
1. 입력과 출력까지의 거리
2. 필요로 하는 의존성
3. 서로 다른 액터( 코드가 비슷하더라도 다른 액터를 처리 시는 `우발적 중복`)
```
- 공통 모듈 관리 -> 모든 모듈이 의존한다는 의미, 변경이 모든 모듈에 영향 

- 대규모 트래픽을 경험해본 적 없는 데 어떻게 대규모 트래픽을 생각해서 이 경우에는 어떤 기술을 사용하고 이 경우에는 비동기 처리하면 된다를 생각할 수 있을 지 
-> `대규모 트래픽`에 집중하는 것보다 API가 어떻게 해야 **빨리** 돌아갈 지 생각하기

## 유저 플로우
1. 설문 목록 조회
- 사용자가 설문 목록 페이지에 접속한다.
- 사용자는 페이지 번호, 페이지 크기, 검색어(선택)를 입력한다.
- 시스템은 해당 조건에 맞는 설문 리스트를 조회하여 반환한다.
- 사용자는 설문 리스트와 각 설문에 대한 간략 정보를 확인한다.
5. 설문 단건 조회
- 사용자가 설문 리스트에서 특정 설문을 선택한다.
- 시스템은 설문 ID에 해당하는 설문 정보와, 그 설문에 속한 질문 리스트를 함께 조회한다.
- 사용자는 설문 상세 정보와 질문 목록을 확인한다.
6. 설문 생성
- 관리자가 설문 생성 페이지에 접속한다.
- 설문 제목, 설명, 질문(문항) 목록을 입력한다.
- 설문 생성 요청을 서버로 전송한다.
- 시스템은 설문과 질문을 저장하고, 생성된 설문 정보를 반환한다.
- 관리자는 생성된 설문을 확인한다.
7. 설문 전체 수정
- 관리자가 설문 수정 페이지에 접속한다.
- 수정할 설문을 선택하고, 설문 전체(제목, 설명, 질문 등)를 수정한다.
- 수정된 내용을 서버로 전송한다.
- 시스템은 설문과 질문 정보를 모두 갱신한다.
- 관리자는 수정된 설문 정보를 확인한다.
8. 설문 일부 수정
- 관리자가 설문 일부만 수정하고자 한다(예: 제목만 변경, 일부 질문만 수정 등).
- 수정할 필드만 입력하여 서버로 전송한다.
- 시스템은 해당 필드만 갱신한다.
- 관리자는 변경된 부분을 확인한다.
9. 설문 삭제
- 관리자가 설문 리스트에서 삭제할 설문을 선택한다.
- 삭제 요청을 서버로 전송한다.
- 시스템은 설문 상태를 '삭제됨'으로 변경한다(실제 데이터는 남아있음).
- 관리자는 설문이 삭제 처리된 것을 확인한다.
10. 사용자 로그인
- 사용자가 로그인 페이지에 접속한다.
- 아이디/비밀번호를 입력한다.
- 로그인 요청을 서버로 전송한다.
- 시스템은 인증 정보를 확인하고, 성공 시 사용자 정보를 반환한다.
- 사용자는 로그인된 상태로 서비스 이용이 가능하다.
11. 내가 참여한 설문 목록 조회
- 사용자가 '내가 참여한 설문' 메뉴에 접속한다.
- 시스템은 해당 사용자가 참여한 설문 리스트를 조회하여 반환한다.
- 사용자는 참여 이력을 확인한다.
12. 설문 응답 조회
- 사용자가 특정 설문에 대해 본인이 제출한 답변을 확인하고자 한다.
- 설문 ID와 사용자 ID로 서버에 요청한다.
- 시스템은 해당 설문에 대한 사용자의 답변을 조회하여 반환한다.
- 사용자는 자신의 답변 내역을 확인한다.
13. 설문 응답 제출
- 사용자가 설문 상세 페이지에서 각 질문에 답변을 입력한다.
- 모든 **필수 문항**에 답변을 입력했는지 확인한다.
- 응답 제출 버튼을 누른다.
- 시스템은 답변을 저장하고, 응답 결과를 반환한다.
- 사용자는 응답 완료 메시지를 확인한다.
14. 관리자 페이지 접근
- 관리자가 /admin 경로로 접근한다.
- 시스템은 관리자 페이지(설문 관리, 사용자 관리 등)를 반환한다.
- 관리자는 관리자 기능을 이용할 수 있다.
